### PR TITLE
Add liberation day for 2020 to Berlin

### DIFF
--- a/src/main/resources/holidays/Holidays_de.xml
+++ b/src/main/resources/holidays/Holidays_de.xml
@@ -20,6 +20,7 @@
     <tns:SubConfigurations hierarchy="be" description="Berlin">
         <tns:Holidays>
             <tns:Fixed month="MARCH" day="8" descriptionPropertiesKey="INTERNATIONAL_WOMAN" validFrom="2019"/>
+            <tns:Fixed month="MAY" day="8" descriptionPropertiesKey="LIBERATION" validFrom="2020" validTo="2020" />
         </tns:Holidays>
     </tns:SubConfigurations>
     <tns:SubConfigurations hierarchy="bb" description="Brandenburg">


### PR DESCRIPTION
In Berlin the 8th of May is a holliday in 2020, see:
https://www.berlin.de/special/jobs-und-ausbildung/nachrichten/berlin/5616720-5510939-8-mai-2020-feiertag-in-berlin.html